### PR TITLE
Brewswitch threshold value configurable

### DIFF
--- a/rancilio-pid/rancilio-pid.ino
+++ b/rancilio-pid/rancilio-pid.ino
@@ -756,7 +756,7 @@ void brew() {
       //  DEBUG_print("brew(): brewswitch=%u | brewing=%u | waitingForBrewSwitchOff=%u\n", brewswitch, brewing, waitingForBrewSwitchOff);
       //  output_timestamp = aktuelleZeit;
       //}
-      if (brewswitch > 700 && not (brewing == 0 && waitingForBrewSwitchOff) ) {
+      if (brewswitch > brewSwitchThrehold && not (brewing == 0 && waitingForBrewSwitchOff) ) {
         totalbrewtime = (preinfusion + preinfusionpause + brewtime) * 1000;
         userActivity = millis();
         
@@ -791,8 +791,8 @@ void brew() {
           brewing = 0;
         }
       }
-  
-      if (brewswitch <= 700) {
+
+      if (brewswitch <= brewSwitchThrehold) {
         if (waitingForBrewSwitchOff) {
           DEBUG_print("brewswitch=off\n");
           userActivity = millis();
@@ -1717,7 +1717,7 @@ void setup() {
   delay(1000);
 
   //if brewswitch is already "on" on startup, then we brew should not start automatically
-  if (OnlyPID == 0 && (analogRead(pinBrewButton) >= 700)) { 
+  if (OnlyPID == 0 && (analogRead(pinBrewButton) >= brewSwitchThrehold)) { 
     DEBUG_print("brewsitch is already on. Dont brew until it is turned off.\n");
     waitingForBrewSwitchOff=true; 
   }

--- a/rancilio-pid/userConfig.h.SAMPLE
+++ b/rancilio-pid/userConfig.h.SAMPLE
@@ -44,6 +44,7 @@
 #define pinRelayPumpe     13   // (ONLYPID=0) trigger relais used to activate the water pump
 #define pinBrewButton     0    // (ONLYPID=0) 0 = default (A0/ADC0) GPIO Port to use to detect brew button press
 #define pinLed            15   // (BREW_READY_LED=1) brewReady LED (16 is also "free" to use)
+#define brewSwitchThrehold 700 // (ONLYPID=0) brew switch level threshold. May have to be lowered if an analog prefilter is used.
 
 
 /*******   


### PR DESCRIPTION
The brewswitch button threshold depends on a lot of external factors, i.e. what kind of circuitry is used to filter the signal etc. Therefore it makes sense to make the threshold configurable.