### PR TITLE
Add support for Thermistor K-type with MAX6675

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,6 +1,7 @@
 [platformio]
 #lib_dir = libraries/
 src_dir = rancilio-pid/
+default_envs = esp32_usb
 
 [env:nodemcuv2_usb]
 platform = espressif8266@^2
@@ -19,6 +20,7 @@ lib_deps =
     pololu/VL53L0X @ ^1.3.0
     martin-ger/uMQTTBroker @ ^1.0.0
     fastled/FastLED @ ^3.4.0
+    adafruit/MAX6675 library @ ^1.1.0
 
 [env:nodemcuv2_ota]
 platform = espressif8266@^2
@@ -41,6 +43,7 @@ lib_deps =
     pololu/VL53L0X @ ^1.3.0
     martin-ger/uMQTTBroker @ ^1.0.0
     fastled/FastLED @ ^3.4.0
+    adafruit/MAX6675 library @ ^1.1.0
 
 [env:esp32_usb]
 platform = espressif32
@@ -60,6 +63,7 @@ lib_deps =
     knolleary/PubSubClient @ ^2.8
     pololu/VL53L0X @ ^1.3.0
     fastled/FastLED @ ^3.4.0
+    adafruit/MAX6675 library @ ^1.1.0
 
 [env:esp32_ota_DEV]
 platform = espressif32
@@ -81,6 +85,7 @@ lib_deps =
     knolleary/PubSubClient @ ^2.8
     pololu/VL53L0X @ ^1.3.0
     fastled/FastLED @ ^3.4.0
+    adafruit/MAX6675 library @ ^1.1.0
 
 [env:esp32_ota_LIVE]
 platform = espressif32
@@ -102,3 +107,4 @@ lib_deps =
     knolleary/PubSubClient @ ^2.8
     pololu/VL53L0X @ ^1.3.0
     fastled/FastLED @ ^3.4.0
+    adafruit/MAX6675 library @ ^1.1.0

--- a/rancilio-pid/rancilio-pid.h
+++ b/rancilio-pid/rancilio-pid.h
@@ -37,6 +37,10 @@
 #define TEMPSENSOR_BITWINDOW 125
 #endif
 
+#ifndef TEMPSENSOR_MAX6675K_MIN_DELAY
+#define TEMPSENSOR_MAX6675K_MIN_DELAY 260
+#endif
+
 #include <RemoteDebug.h> //https://github.com/JoaoLopesF/RemoteDebug
 extern RemoteDebug Debug;
 
@@ -75,6 +79,7 @@ double pastTemperatureChange(int);
 double pastTemperatureChange(int, bool);
 
 double getCurrentTemperature();
+float readTemperatureFromSensor();
 
 bool almostEqual(float, float);
 

--- a/rancilio-pid/userConfig.h.SAMPLE
+++ b/rancilio-pid/userConfig.h.SAMPLE
@@ -10,6 +10,7 @@
  * General settings
  *****************************************************/
 #define MACHINE_TYPE "rancilio"  // supported values are "rancilio", "gaggia" and "ecm".
+#define TEMPSENSOR 2          // 2=TSIC306; 3=MAX6675K (1=DS19B20 not supported anymore)
 
 #define FORCE_OFFLINE 0       // 0=Use network | 1=Disable all network stuff (WiFi, MQTT, Blynk).
 #define DISABLE_SERVICES_ON_STARTUP_ERRORS 1 // 1=on (default) when a service cannot be connected during startup, never retry | 0=off Try reconnecting to service during regular operations.
@@ -34,7 +35,7 @@
 #define ENABLE_HARDWARE_LED_RGB_ON  LightGreen  // (ENABLE_HARDWARE_LED=2) Color name when leds should be turned on. List of Colours: https://github.com/FastLED/FastLED/wiki/Pixel-reference
 #define ENABLE_HARDWARE_LED_RGB_OFF LightPink  // (ENABLE_HARDWARE_LED=2) Color name when leds should be turned off.
 
-//#define DEBUGMODE                // to enable Debug uncomment this line. Afterwards you can connect via telnet to pot 23 to see debug logs.
+//#define DEBUGMODE                // to enable Debug uncomment this line. Afterwards you can connect via telnet to port 23 to see debug logs.
 #define ENABLE_CALIBRATION_MODE 0  // 0=off (default). 1=on. If on, PID is disabled and CALIBRATION information is logged in DEBUG log (eg. CONTROLS_CONFIG, WATER_LEVEL_SENSOR)
 
 
@@ -52,6 +53,11 @@
 #define pinBrewAction      15
 #define pinHotwaterAction   5
 #define pinSteamingAction   2
+
+// Pin mapping for MAX6675
+#define pinTemperatureSO  19
+#define pinTemperatureCS  5
+#define pinTemperatureCLK 18
 
 /*******
  * GPIO Pin Usage: Here you can define how the GPIO boards (analog/digital) shall be used to execute functions.


### PR DESCRIPTION
I added support for a thermistor K-type connected via MAX6675.
This sensors are quite cheap and have the advantage that they already come with a M3 or M4 thread, which can be used for modding the Gaggia. 
They are sold as "3D Printer Head Thermocouple" e.g. on Aliexpress or Ebay