### PR TITLE
add SH1106 in SPI, fix DISPLAY_HARDWARE config

### DIFF
--- a/rancilio-pid/display.h
+++ b/rancilio-pid/display.h
@@ -15,6 +15,9 @@ const int Display = DISPLAY_HARDWARE;
 #endif
 #include <U8g2lib.h>
 #include <Wire.h>
+#if (DISPLAY_HARDWARE == 3)
+#include <SPI.h>
+#endif
 
 #ifdef ESP32
 static int activeStateBuffer;
@@ -25,11 +28,16 @@ static char displaymessagetext2Buffer[30];
 #define SCREEN_WIDTH 128 // OLED display width, in pixels
 #define SCREEN_HEIGHT 64 // OLED display height, in pixels
 
-#if (DISPLAY == 1)
+#if (DISPLAY_HARDWARE == 1)
 // Attention: refresh takes around 42ms (esp32: 26ms)!
 U8G2_SH1106_128X64_NONAME_F_HW_I2C u8g2(U8G2_R0, /* reset=*/U8X8_PIN_NONE); // e.g. 1.3"
-#else
+#elif (DISPLAY_HARDWARE == 2)
 U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2(U8G2_R0, /* reset=*/U8X8_PIN_NONE); // e.g. 0.96"
+#else
+// 23-MOSI 18-CLK
+#define OLED_CS             5
+#define OLED_DC             2
+U8G2_SH1106_128X64_NONAME_F_4W_HW_SPI u8g2(U8G2_R0, OLED_CS, OLED_DC, /* reset=*/U8X8_PIN_NONE); // e.g. 1.3"
 #endif
 unsigned long previousMillisDisplay = 0; // initialisation at the end of init()
 const long intervalDisplay = 1000; // Update für Display

--- a/rancilio-pid/display.ino
+++ b/rancilio-pid/display.ino
@@ -6,7 +6,11 @@
 
 void u8g2_init(void) {
 #ifdef ESP32
+#if (DISPLAY_HARDWARE == 3)
+  u8g2.setBusClock(600000);
+#else
   u8g2.setBusClock(2000000);
+#endif
 #endif
   u8g2.begin();
   u8g2_prepare();

--- a/rancilio-pid/userConfig.h.SAMPLE
+++ b/rancilio-pid/userConfig.h.SAMPLE
@@ -118,7 +118,8 @@
 /*******
  * Display Settings
  *******/
-#define DISPLAY_HARDWARE 0                // 0=Deaktiviert, 1=SH1106_128X64, 2=SSD1306_128X64
+#define DISPLAY_HARDWARE 0                // 0=Deaktiviert, 1=SH1106_128X64_I2C, 2=SSD1306_128X64_I2C, 3=SH1106_126x64_SPI
+                                          // for 3 (SH1106 SPI) use P23=MOSI P18=CLK P5=OLED_CS P2=OLED_DC (see display.h)
 #define ROTATE_DISPLAY 0                  // 0=Off (Default), 1=180 degree clockwise rotation
 #define DISPLAY_TEXT_STATE 1              // 1=On  (Default), 0=Off display text of Maschine-state
 #define ICON_COLLECTION 0                 // 0:="simple", 1:="smiley", 2:="winter", 3:="text"


### PR DESCRIPTION
I accidentally bought SH1106 that can work only in SPI mode, so I added a config support for that. Also, there was a bug with DISPLAY_HARDWARE naming, which didn't really work.