### PR TITLE
allow user to configure I2C pins for OLED screen

### DIFF
--- a/rancilio-pid/display.h
+++ b/rancilio-pid/display.h
@@ -30,9 +30,9 @@ static char displaymessagetext2Buffer[30];
 
 #if (DISPLAY_HARDWARE == 1)
 // Attention: refresh takes around 42ms (esp32: 26ms)!
-U8G2_SH1106_128X64_NONAME_F_HW_I2C u8g2(U8G2_R0, /* reset=*/U8X8_PIN_NONE); // e.g. 1.3"
+  U8G2_SH1106_128X64_NONAME_F_HW_I2C u8g2(U8G2_R0, /* reset=*/U8X8_PIN_NONE, DISPLAY_I2C_SCL, DISPLAY_I2C_SDA); // e.g. 1.3"
 #elif (DISPLAY_HARDWARE == 2)
-U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2(U8G2_R0, /* reset=*/U8X8_PIN_NONE); // e.g. 0.96"
+  U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2(U8G2_R0, /* reset=*/U8X8_PIN_NONE, DISPLAY_I2C_SCL, DISPLAY_I2C_SDA); // e.g. 0.96"
 #else
 // 23-MOSI 18-CLK
 #define OLED_CS             5

--- a/rancilio-pid/userConfig.h.SAMPLE
+++ b/rancilio-pid/userConfig.h.SAMPLE
@@ -120,6 +120,8 @@
  *******/
 #define DISPLAY_HARDWARE 0                // 0=Deaktiviert, 1=SH1106_128X64_I2C, 2=SSD1306_128X64_I2C, 3=SH1106_126x64_SPI
                                           // for 3 (SH1106 SPI) use P23=MOSI P18=CLK P5=OLED_CS P2=OLED_DC (see display.h)
+#define DISPLAY_I2C_SCL 22                // SCL for OLED display; P22 on ESP32 by default
+#define DISPLAY_I2C_SDA 21                // SDA for OLED display; P21 on ESP32 by default
 #define ROTATE_DISPLAY 0                  // 0=Off (Default), 1=180 degree clockwise rotation
 #define DISPLAY_TEXT_STATE 1              // 1=On  (Default), 0=Off display text of Maschine-state
 #define ICON_COLLECTION 0                 // 0:="simple", 1:="smiley", 2:="winter", 3:="text"


### PR DESCRIPTION
By default, I2C bus 1 pins are configured for OLED, but this PR allows a user to move them elsewhere. I have mine OLED on arbitrary pins and everything works fine (and left ToF sensor on I2C bus 1).